### PR TITLE
The XPath expression is now correctly brought into the inventory.

### DIFF
--- a/modules/cts.xql
+++ b/modules/cts.xql
@@ -132,7 +132,7 @@ declare %private function ctsh:generateXpathScope($refPattern as node()*) as nod
         ()
     else
         let $node := $refPattern[1]/@replacementPattern
-        let $regexp := "/+[a-zA-Z0-9:\[\]@=\\\{\$'\.]+"
+        let $regexp := "/+[a-zA-Z0-9:\[\]@=\\\{\$'\.\s]+"
         let $matches := functx:get-matches($node, $regexp)[. != ""]
         let $count := count($matches)
         let $scope := fn:subsequence($matches, 1, $count - 1)


### PR DESCRIPTION
However, when making a CTS request, it seems to do the same thing, i.e., to cut the xpath expression at the space.  This is almost certainly a problem with CTS5-XQ
